### PR TITLE
FOGL-3424 Debian postrm script improvised as per different cases to follow with

### DIFF
--- a/packages/Debian/common/DEBIAN/postrm
+++ b/packages/Debian/common/DEBIAN/postrm
@@ -35,5 +35,25 @@ remove_fledge_sudoer_file() {
     rm -rf /etc/sudoers.d/fledge
 }
 
-echo "Remove fledge sudoers file"
 remove_fledge_sudoer_file
+case "$1" in
+  remove|purge)
+    echo "Cleanup of files"
+    remove_unused_files
+    echo "Remove fledge sudoers file"
+    remove_fledge_sudoer_file
+    ;;
+  disappear)
+    ;;
+  upgrade)
+    ;;
+  failed-upgrade)
+    ;;
+  abort-install)
+    ;;
+  abort-upgrade)
+    ;;
+  *) echo "$0: didn't understand being called with \`$1'" 1>&2
+     exit 0;;
+esac
+exit 0

--- a/packages/Debian/common/DEBIAN/postrm
+++ b/packages/Debian/common/DEBIAN/postrm
@@ -35,7 +35,6 @@ remove_fledge_sudoer_file() {
     rm -rf /etc/sudoers.d/fledge
 }
 
-remove_fledge_sudoer_file
 case "$1" in
   remove|purge)
     echo "Cleanup of files"

--- a/packages/Debian/common/DEBIAN/preinst
+++ b/packages/Debian/common/DEBIAN/preinst
@@ -84,7 +84,8 @@ then
         exit 1
     fi
 
-    # Avoid the execution of the function during an upgrade
+    # Below workaround needed only when we upgrade from 1.8.0 ONLY
+    # As Debian flow be like 1.8.0.prerm => .next.preinst => 1.8.0.postrm => .next.postinst
     sed -i -e 's/^remove_unused_files$/#remove_unused_files/' /var/lib/dpkg/info/fledge.postrm
 
     # Persist current version in case of upgrade/downgrade


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

From this way we can handle different cases in postrm script, so that it handles in a correct way

I have tested below
**Test scenarios:**

_Fresh_
1) Installed 1.8.1 (latest develop core with bump version)
2) Also checked purge/remove - It will keep **/usr/ocal/fledge/data** directory only

_Upgrade_
1) Installed 1.8.1 over 1.8.0
2) Installed 1.8.2 (created another one with some changes in core like modifies PING result etc.) over 1.8.1
3) Also checked purge/remove - It will keep **/usr/ocal/fledge/data** directory only

_Downgrade_
No test against this it's tricky to make it work
See one of the case like foglamp_schema=34, Downgrade is NOT possible as we removed C-source binaries.

**NOTE** We already have a JIRA for automating packaging based testing via FOGL-4184 
