### PR TITLE
ca-certificates and curl dep for stretch (debian9) on moxa gateway

### DIFF
--- a/packages/Debian/armv7l/DEBIAN/control
+++ b/packages/Debian/armv7l/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0.0
 Section: devel
 Priority: optional
 Architecture: armhf
-Depends: autoconf,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,libpq-dev,python3-pip,python3-setuptools,sqlite3,sudo,cpulimit,krb5-user,libcurl4-openssl-dev
+Depends: autoconf,ca-certificates,curl,libcurl4-openssl-dev,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,libpq-dev,python3-pip,python3-setuptools,sqlite3,sudo,cpulimit,krb5-user
 Conflicts:
 Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
 Homepage: http://www.dianomic.com


### PR DESCRIPTION
> stretch Raspbian image

Both ca-certificates and curl are installed.

> debian 9 (not armhf but amd64)

ca-certificates is installed (if we try sudo apt install ca-certificates, it says already a newest version | also can see that in installed list), curl is not there.

moxa gateway has their own linux (debian stretch / armhf based) which doesn't have curl or ca-certificates installed.