### PR TITLE
FOGL-4195 RPM packaging scripts revamped & its install/upgrade/remove flow fixes

### DIFF
--- a/packages/RPM/SPECS/fledge.spec
+++ b/packages/RPM/SPECS/fledge.spec
@@ -19,10 +19,30 @@ AutoReqProv:   no
 %description
 Fledge, the open source platform for the Internet of Things
 
+
+## -------------------------------------------------------------------------------------------------
+## Scriptlet values which we must use in our scripts
+
+## scriptlet     install          upgrade          uninstall
+## %pre          $1 == 1          $1 == 2          (N/A)
+## %post         $1 == 1          $1 == 2          (N/A)
+## %preun        (N/A)            $1 == 1          $1 == 0
+## %postun       (N/A)            $1 == 1          $1 == 0
+
+
+## On upgrade, the scripts are run in the following order:
+
+## %pre of new package
+## %post of new package
+## %preun of old package
+## %postun of old package
+
+## --------------------------------------------------------------------------------------------------
+
 %pre
 #!/usr/bin/env bash
 
-##--------------------------------------------------------------------
+##---------------------------------------------------------------------------------------------------
 ## Copyright (c) 2019 Dianomic Systems Inc.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,15 +56,15 @@ Fledge, the open source platform for the Internet of Things
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
-##--------------------------------------------------------------------
+##---------------------------------------------------------------------------------------------------
 
-##--------------------------------------------------------------------
+##---------------------------------------------------------------------------------------------------
 ##
-## This script is used to execute pre installation tasks.
+## The %pre scriptlet executes just before the package is to be installed.
 ##
-## Author: Ivan Zoratti, Ashwin Gopalakrishnan, Massimiliano Pinto, Stefano Simonelli
+## Author: Ivan Zoratti, Ashwin Gopalakrishnan, Massimiliano Pinto, Stefano Simonelli, Ashish Jabble
 ##
-##--------------------------------------------------------------------
+##---------------------------------------------------------------------------------------------------
 
 set -e
 
@@ -52,7 +72,7 @@ PKG_NAME="fledge"
 
 is_fledge_installed () {
 	set +e
-    rc=`rpm -qa  2> /dev/null  | grep -Fx ${PKG_NAME}`
+    rc=$(rpm -ql ${PKG_NAME} | grep 'fledge/bin/fledge$')
     echo $rc
     set -e
 }
@@ -86,29 +106,59 @@ exists_schema_change_path () {
     echo 1
 }
 
+stop_fledge_service () {
+    systemctl stop fledge
+}
+
+kill_fledge () {
+    set +e
+    fledge_script=$(get_fledge_script)
+    fledge_status_output=$($fledge_script kill 2>&1)
+    set -e
+}
+
+disable_fledge_service () {
+	set +e
+	/sbin/chkconfig fledge off
+    set -e
+}
+
+remove_fledge_service_file () {
+    rm -rf /etc/init.d/fledge
+}
+
+reset_systemctl () {
+    systemctl daemon-reload
+    systemctl reset-failed
+}
+
 # main
-
-# check if fledge is installed
-IS_FLEDGE_INSTALLED=$(is_fledge_installed)
-
-# if fledge is installed...
-if [ "$IS_FLEDGE_INSTALLED" -eq "1" ]
-then
-    echo "Fledge is already installed: this is an upgrade/downgrade."
-
-    # exit if fledge is running
+if [ $1 == 1 ];then
+    echo "pre step: ${PKG_NAME} is getting installed."
+elif [ $1 == 2 ];then
+    echo "preun step: ${PKG_NAME} is getting upgraded"
     IS_FLEDGE_RUNNING=$(is_fledge_running)
     if [ "$IS_FLEDGE_RUNNING" -eq "1" ]
     then
-        echo "*** ERROR. Fledge is currently running. Stop Fledge and try again. ***"
-        exit 1
+        echo "${PKG_NAME} is currently running."
+        echo "Stop ${PKG_NAME} service."
+        stop_fledge_service
+        echo "Kill ${PKG_NAME}."
+        kill_fledge
     fi
+
+    echo "Disable ${PKG_NAME} service."
+    disable_fledge_service
+    echo "Remove ${PKG_NAME} service script"
+    remove_fledge_service_file
+    echo "Reset systemctl"
+    reset_systemctl
 
     # Persist current version in case of upgrade/downgrade
     installed_version=`rpm -qi ${PKG_NAME} | grep Version |awk '{print $3}'`
     if [ "${installed_version}" ]
     then
-        # Persist current Fledge version: it will be removed by postinstall script
+        # Persist current ${PKG_NAME} version: it will be removed by postinstall script
         this_dir=`pwd`
         cd /usr/local/fledge/
         echo "${installed_version}" > .current_installed_version
@@ -118,22 +168,20 @@ then
     # check schema version file, exit if schema change path does not exist
     CURRENT_VERSION_FILE=$(get_current_version_file)
     CURRENT_SCHEMA_VERSION=$(get_schema_version $CURRENT_VERSION_FILE)
-    echo "Fledge currently has schema version $CURRENT_SCHEMA_VERSION"
+    echo "${PKG_NAME} currently has schema version $CURRENT_SCHEMA_VERSION"
     EXISTS_SCHEMA_CHANGE_PATH=$(exists_schema_change_path)
     if [ "$EXISTS_SCHEMA_CHANGE_PATH" -eq "0" ]
     then
         echo "*** ERROR. There is no schema change path from the installed version to the new version. ***"
         exit 1
     fi
-
 fi
-
 
 
 %preun
 #!/usr/bin/env bash
 
-##--------------------------------------------------------------------
+##--------------------------------------------------------------------------------
 ## Copyright (c) 2019 Dianomic Systems Inc.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -147,15 +195,15 @@ fi
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
-##--------------------------------------------------------------------
+##--------------------------------------------------------------------------------
 
-##--------------------------------------------------------------------
+##--------------------------------------------------------------------------------
 ##
-## This script is used to execute before the removal of files associated with the package.
+## The %preun scriptlet executes just before the package is to be erased.
 ##
-## Author: Ivan Zoratti, Ashwin Gopalakrishnan, Stefano Simonelli
+## Author: Ivan Zoratti, Ashwin Gopalakrishnan, Stefano Simonelli, Ashish Jabble
 ##
-##----------------------------------------------------------------------------------------
+##--------------------------------------------------------------------------------
 
 set -e
 
@@ -202,30 +250,33 @@ reset_systemctl () {
 }
 
 # main
+if [ $1 == 1 ];then
+    echo "preun step: ${PKG_NAME} is getting upgraded. But Nothing to upgrade."
+elif [ $1 == 0 ];then
+    echo "preun step: ${PKG_NAME} is getting removed/uninstalled"
+    IS_FLEDGE_RUNNING=$(is_fledge_running)
+    if [ "$IS_FLEDGE_RUNNING" -eq "1" ]
+    then
+        echo "${PKG_NAME} is currently running."
+        echo "Stop ${PKG_NAME} service."
+        stop_fledge_service
+        echo "Kill ${PKG_NAME}."
+        kill_fledge
+    fi
 
-IS_FLEDGE_RUNNING=$(is_fledge_running)
-
-if [ "$IS_FLEDGE_RUNNING" -eq "1" ]
-then
-    echo "Fledge is currently running."
-    echo "Stop Fledge service."
-    stop_fledge_service
-    echo "Kill Fledge."
-    kill_fledge
+    echo "Disable ${PKG_NAME} service."
+    disable_fledge_service
+    echo "Remove ${PKG_NAME} service script"
+    remove_fledge_service_file
+    echo "Reset systemctl"
+    reset_systemctl
 fi
-
-echo "Disable Fledge service."
-disable_fledge_service
-echo "Remove Fledge service script"
-remove_fledge_service_file
-echo "Reset systemctl"
-reset_systemctl
 
 
 %post
 #!/usr/bin/env bash
 
-##--------------------------------------------------------------------
+##----------------------------------------------------------------------------
 ## Copyright (c) 2019 Dianomic Systems Inc.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -239,15 +290,15 @@ reset_systemctl
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
-##--------------------------------------------------------------------
+##----------------------------------------------------------------------------
 
-##--------------------------------------------------------------------
+##----------------------------------------------------------------------------
 ##
-## This script is used to execute post installation tasks.
+## The %post scriptlet executes just after the package is to be installed.
 ##
-## Author: Ivan Zoratti, Massimiliano Pinto, Stefano Simonelli
+## Author: Ivan Zoratti, Massimiliano Pinto, Stefano Simonelli, Ashish Jabble
 ##
-##--------------------------------------------------------------------
+##----------------------------------------------------------------------------
 
 set -e
 
@@ -274,7 +325,6 @@ copy_service_file() {
 }
 
 enable_fledge_service() {
-
 	/sbin/chkconfig fledge on
 }
 
@@ -351,9 +401,10 @@ install_pip3_packages () {
 	fi
 	source scl_source enable rh-python36
 
-	pip install -Ir /usr/local/fledge/python/requirements.txt
+    # TODO: we may need with --no-cache-dir
+	pip3 install -Ir /usr/local/fledge/python/requirements.txt
 
-	sudo bash -c 'source scl_source enable rh-python36;pip install dbus-python'
+	sudo bash -c 'source scl_source enable rh-python36;pip3 install dbus-python'
 	set -e
 }
 
@@ -378,7 +429,6 @@ call_package_update_script () {
 
 
 # main
-
 echo "Install python dependencies"
 install_pip3_packages
 
@@ -418,7 +468,7 @@ start_fledge_service
 %postun
 #!/usr/bin/env bash
 
-##--------------------------------------------------------------------
+##--------------------------------------------------------------------------
 ## Copyright (c) 2019 Dianomic Systems Inc.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -432,17 +482,18 @@ start_fledge_service
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
-##--------------------------------------------------------------------
+##--------------------------------------------------------------------------
 
-##--------------------------------------------------------------------
+##--------------------------------------------------------------------------
 ##
-## This script is used to modifies links or other files associated with fledge, and/or removes files created by the package.
+## The %postun scriptlet executes just after the package is to be erased.
 ##
 ## Author: Ashish Jabble
 ##
-##--------------------------------------------------------------------
+##--------------------------------------------------------------------------
 
 set -e
+PKG_NAME="fledge"
 
 remove_unused_files () {
   find /usr/local/fledge/ -maxdepth 1 -mindepth 1 -type d | egrep -v -w '(/usr/local/fledge/data)' | xargs rm -rf
@@ -452,11 +503,17 @@ remove_fledge_sudoer_file() {
     rm -rf /etc/sudoers.d/fledge
 }
 
-echo "Cleanup of files"
-remove_unused_files
+# main
+if [ $1 == 1 ];then
+    echo "postun step: ${PKG_NAME} is getting upgraded. But nothing to upgrade."
+elif [ $1 == 0 ];then
+    echo "postun step: ${PKG_NAME} is getting removed/uninstalled"
+    echo "Cleanup of files"
+    remove_unused_files
+    echo "Remove fledge sudoers file"
+    remove_fledge_sudoer_file
+fi
 
-echo "Remove fledge sudoers file"
-remove_fledge_sudoer_file
 
 %files
 %{install_path}/*

--- a/packages/RPM/SPECS/fledge.spec
+++ b/packages/RPM/SPECS/fledge.spec
@@ -134,9 +134,10 @@ reset_systemctl () {
 
 # main
 if [ $1 == 1 ];then
-    echo "pre step: ${PKG_NAME} is getting installed."
+    echo "pre scriptlet is called: ${PKG_NAME} is getting installed."
+    # Add steps here for the fresh installed case for this scriptlet
 elif [ $1 == 2 ];then
-    echo "preun step: ${PKG_NAME} is getting upgraded"
+    echo "pre scriptlet is called: ${PKG_NAME} is getting upgraded."
     IS_FLEDGE_RUNNING=$(is_fledge_running)
     if [ "$IS_FLEDGE_RUNNING" -eq "1" ]
     then
@@ -251,9 +252,9 @@ reset_systemctl () {
 
 # main
 if [ $1 == 1 ];then
-    echo "preun step: ${PKG_NAME} is getting upgraded. But Nothing to upgrade."
+    echo "preun scriptlet is called: ${PKG_NAME} is getting upgraded."
 elif [ $1 == 0 ];then
-    echo "preun step: ${PKG_NAME} is getting removed/uninstalled"
+    echo "preun scriptlet is called: ${PKG_NAME} is getting removed/uninstalled."
     IS_FLEDGE_RUNNING=$(is_fledge_running)
     if [ "$IS_FLEDGE_RUNNING" -eq "1" ]
     then
@@ -505,9 +506,10 @@ remove_fledge_sudoer_file() {
 
 # main
 if [ $1 == 1 ];then
-    echo "postun step: ${PKG_NAME} is getting upgraded. But nothing to upgrade."
+    echo "postun scriptlet is called: ${PKG_NAME} is getting upgraded."
+    # Add steps here for the upgrade case for this scriptlet
 elif [ $1 == 0 ];then
-    echo "postun step: ${PKG_NAME} is getting removed/uninstalled"
+    echo "postun scriptlet is called: ${PKG_NAME} is getting removed/uninstalled."
     echo "Cleanup of files"
     remove_unused_files
     echo "Remove fledge sudoers file"


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Test scenarios:**

**Fresh installation**
* Installed 1.8.0 (latest develop core) - success
* Also checked purge/remove - It will keep /usr/ocal/fledge/data directory only

**Upgrade**
* Installed 1.8.1 (latest develop + bumped version and did some changes in PING response so that we know new changes are IN) over 1.8.0 - success
* Also checked purge/remove - It will keep /usr/ocal/fledge/data directory only

_Downgrade_
We have not  supported yet


**Notes**
1) You can't upgrade from release 1.8.0 to the next version (say 1.8.1). As preun & posting scriptlets are executing at the end of package. As of now I don't even have the around the patch/workaround as per RPM they were storing scriptlets into SHA's and will NOT be able to amend the scripts
Though we can see the content of scripts via `$ rpm -qa --scripts fledge` but there is NO physical location exists as such.
As we did patch placed in our debian /var/lib/dpkg/info/fledge*. but in RPM I couldn't find any related stuff.

2) You may see some warning in remove package. At the moment ignore these as it does not impact. Still investigating if I can fix around that
```
warning: file /usr/local/foglamp/data.new/extras/fogbench/fogbench_sensor_coap.template.json: remove failed: No such file or directory
warning: file /usr/local/foglamp/data.new/extras/fogbench: remove failed: No such file or directory
warning: file /usr/local/foglamp/data.new/extras: remove failed: No such file or directory
warning: file /usr/local/foglamp/data.new/etc/kerberos/README.rst: remove failed: No such file or directory
warning: file /usr/local/foglamp/data.new/etc/kerberos: remove failed: No such file or directory
warning: file /usr/local/foglamp/data.new/etc/certs: remove failed: No such file or directory
warning: file /usr/local/foglamp/data.new/etc: remove failed: No such file or directory
warning: file /usr/local/foglamp/data.new: remove failed: No such file or directory
```