### PR TITLE
FOGL-5807 python based notification delivery and rules directory added in service packaging for both debian & RPM

### DIFF
--- a/service/make_deb
+++ b/service/make_deb
@@ -128,12 +128,13 @@ do
     package_name="${pkg_name}-${version}-${architecture}"
 
     # Print the summary of findings
-    echo "The package root directory is     : ${GIT_ROOT}"
-    echo "The package build directory is    : ${BUILD_ROOT}"
-    echo "The Fledge required version      : ${fledge_version}"
-    echo "The architecture is set as        : ${architecture}"
-    echo "The package will be built in      : ${archive}/${architecture}"
-    echo "The package name is               : ${package_name}"
+    echo "The package root directory is                           : ${GIT_ROOT}"
+    echo "The package build directory is                          : ${BUILD_ROOT}"
+    echo "The Fledge required version                             : ${fledge_version}"
+    echo "The Fledge service ${service_name} version is              : ${version}"
+    echo "The architecture is set as                              : ${architecture}"
+    echo "The package will be built in                            : ${archive}/${architecture}"
+    echo "The package name is                                     : ${package_name}"
     echo
 
     # Create the package directory. If a directory with the same name exists,
@@ -193,6 +194,8 @@ do
     if [ "${service_name}" = "notification" ]; then
         mkdir -p plugins/notificationDelivery
         mkdir -p plugins/notificationRule
+        mkdir -p python/fledge/plugins/notificationDelivery
+        mkdir -p python/fledge/plugins/notificationRule
     fi
     mkdir -p ${install_dir}
     cp "${GIT_ROOT}/build/C/${install_dir}/${service_name}/${exec_name}" "${install_dir}/${exec_name}"

--- a/service/make_rpm
+++ b/service/make_rpm
@@ -229,7 +229,7 @@ EOF
     cp -R --preserve=links ${GIT_ROOT}/build/C/${install_dir}/notification/fledge* "${install_dir}/"
     echo "Done."
     cd ..
-    find -L . -exec echo '%{install_path}/'{} \; >> ../../../../SPECS/service.spec
+    find -L . -type f -exec echo '%{install_path}/'{} \; >> ../../../../SPECS/service.spec
     cd "${BUILD_ROOT}"
     echo "Building the RPM package..."
     rpmbuild --define "_topdir ${BUILD_ROOT}/${package_name}" --noclean -bb ${BUILD_ROOT}/${package_name}/SPECS/service.spec

--- a/service/make_rpm
+++ b/service/make_rpm
@@ -187,7 +187,7 @@ do
     if [ -d "${package_name}" ]; then
         rm -rf ${package_name}*
     fi
-    mkdir "${package_name}"
+    mkdir -p "${package_name}"
 
     # Populate the package directory with RPM files
     echo -n "Populating the package and updating version file..."
@@ -211,11 +211,12 @@ EOF
     sed -i -f /tmp/sed.script.$$ SPECS/service.spec
     rm /tmp/sed.script.$$
 
-    mkdir BUILDROOT
+    # RPM file structure
+    echo "Copying artifacts..."
+    mkdir -p BUILDROOT
     cd BUILDROOT
     mkdir -p ${package_name}-1.${arch}
     cd ${package_name}-1.${arch}
-
     mkdir -p usr/local/fledge
     cd usr/local/fledge
     if [ "${service_name}" = "notification" ]; then
@@ -227,21 +228,18 @@ EOF
     mkdir -p ${install_dir}
     cp -R --preserve=links ${GIT_ROOT}/build/C/${install_dir}/notification/fledge* "${install_dir}/"
     echo "Done."
-
     cd ..
-    find -L . -type f -exec echo '%{install_path}/'{} \; >> ../../../../SPECS/service.spec
+    find -L . -exec echo '%{install_path}/'{} \; >> ../../../../SPECS/service.spec
     cd "${BUILD_ROOT}"
-    echo "Building the package..."
+    echo "Building the RPM package..."
     rpmbuild --define "_topdir ${BUILD_ROOT}/${package_name}" --noclean -bb ${BUILD_ROOT}/${package_name}/SPECS/service.spec
     echo "Building Complete."
-
     # Full Package name
     fullname="${package_name}-1.${arch}.rpm"
-
     # Move final package and its spec file to archive/arch directory
     cp ${BUILD_ROOT}/${package_name}/RPMS/${arch}/${fullname} ${archive}/${arch}/${fullname}
     cp ${BUILD_ROOT}/${package_name}/SPECS/service.spec ${archive}/${arch}
-
+    # Remove /tmp cloned directory
     rm -rf /tmp/${REPO_NAME}
     exit 0
 done

--- a/service/make_rpm
+++ b/service/make_rpm
@@ -156,8 +156,8 @@ do
     # Print the summary of findings
     echo "The package root directory is                           : ${GIT_ROOT}"
     echo "The package build directory is                          : ${BUILD_ROOT}"
-    echo "The Fledge required version                            : ${fledge_version}"
-    echo "The Fledge service ${service_name} version is          : ${version}"
+    echo "The Fledge required version                             : ${fledge_version}"
+    echo "The Fledge service ${service_name} version is              : ${version}"
     echo "The architecture is set as                              : ${arch}"
     echo "The package will be built in                            : ${archive}/${architecture}"
     echo "The package name is                                     : ${package_name}"
@@ -221,6 +221,8 @@ EOF
     if [ "${service_name}" = "notification" ]; then
         mkdir -p plugins/notificationDelivery
         mkdir -p plugins/notificationRule
+        mkdir -p python/fledge/plugins/notificationDelivery
+        mkdir -p python/fledge/plugins/notificationRule
     fi
     mkdir -p ${install_dir}
     cp -R --preserve=links ${GIT_ROOT}/build/C/${install_dir}/notification/fledge* "${install_dir}/"

--- a/service/packages/RPM/SPECS/service.spec
+++ b/service/packages/RPM/SPECS/service.spec
@@ -29,7 +29,7 @@ PKG_NAME="__PACKAGE_NAME__"
 %post
 set -e
 set_files_ownership () {
-	chown -R root:root /usr/local/fledge/__INSTALL_DIR__
+    chown -R root:root /usr/local/fledge/__INSTALL_DIR__
 }
 
 # main
@@ -38,3 +38,7 @@ set_files_ownership
 
 
 %files
+%{install_path}/fledge/plugins/notificationDelivery
+%{install_path}/fledge/plugins/notificationRule
+%{install_path}/fledge/python/fledge/plugins/notificationDelivery
+%{install_path}/fledge/python/fledge/plugins/notificationRule


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

Custom Packages available at http://archives.fledge-iot.org/fixes/FOGL-5807/

*Debian package contents*

```
$ sudo dpkg -c fledge-service-notification-1.9.1-x86_64_new.deb 
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/fledge/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/fledge/plugins/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/fledge/plugins/notificationDelivery/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/fledge/plugins/notificationRule/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/fledge/python/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/fledge/python/fledge/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/fledge/python/fledge/plugins/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/fledge/python/fledge/plugins/notificationDelivery/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/fledge/python/fledge/plugins/notificationRule/
drwxrwxr-x ubuntu/ubuntu     0 2021-08-10 11:45 ./usr/local/fledge/services/
-rwxrwxr-x ubuntu/ubuntu 1019128 2021-08-10 11:45 ./usr/local/fledge/services/fledge.services.notification
```

**RPM package contents**
```
/usr/local/fledge/plugins/notificationDelivery
/usr/local/fledge/plugins/notificationRule
/usr/local/fledge/python/fledge/plugins/notificationDelivery
/usr/local/fledge/python/fledge/plugins/notificationRule
/usr/local/fledge/services/fledge.services.notification
```