### PR TITLE
Package name updated based on standard convention

### DIFF
--- a/make_deb
+++ b/make_deb
@@ -129,7 +129,7 @@ fi
 version=`cat ${FLEDGE_ROOT}/VERSION | tr -d ' ' | grep 'fledge_version=' | head -1 | sed -e 's/\(.*\)=\(.*\)/\2/g'`
 BUILD_ROOT="${PKG_ROOT}/packages/Debian/build/${architecture}"
 # Final package name
-if [[ $skip_build == 0 ]] && ([[ ${branch} != "main" ]] && [[ ! ${branch} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]]); then package_name="fledge_${version}-${commit_count}_${architecture}"; version=${git_tag_info:1}; else package_name="fledge-${version}-${architecture}"; fi
+if [[ $skip_build == 0 ]] && ([[ ${branch} != "main" ]] && [[ ! ${branch} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]]); then package_name="fledge_${version}-${commit_count}_${architecture}"; version=${git_tag_info:1}; else package_name="fledge_${version}_${architecture}"; fi
 
 # Print the summary of findings
 echo "The package root directory is : ${PKG_ROOT}"

--- a/others/make_deb
+++ b/others/make_deb
@@ -93,7 +93,7 @@ pkg_name="fledge-${ADDITIONAL_LIB_NAME}"
 arch_name=$(dpkg --print-architecture)
 git_tag_info=$(git describe --tags) && commit_count=$(echo ${git_tag_info} | cut -d- -f2) || { commit_count=$(git rev-list --count HEAD); git_tag_info="v$version-$commit_count-g$(git rev-parse --short HEAD)"; }
 branch_name=$(git rev-parse --abbrev-ref HEAD)
-if [[ ${branch_name} != "main" ]] && [[ ! ${branch_name} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]]; then package_name="${pkg_name}_${version}-${commit_count}_${architecture}"; version=${git_tag_info:1}; else package_name="${pkg_name}-${version}-${architecture}"; fi
+if [[ ${branch_name} != "main" ]] && [[ ! ${branch_name} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]]; then package_name="${pkg_name}_${version}-${commit_count}_${architecture}"; version=${git_tag_info:1}; else package_name="${pkg_name}_${version}_${architecture}"; fi
 
 if [ ! -d "${archive}/${architecture}" ]; then
     mkdir -p "${archive}/${architecture}"

--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -126,7 +126,7 @@ do
     git_tag_info=$(git describe --tags) && commit_count=$(echo ${git_tag_info} | cut -d- -f2) || { commit_count=$(git rev-list --count HEAD); git_tag_info="v$version-$commit_count-g$(git rev-parse --short HEAD)"; }
     # Final package name
     archname=$(dpkg --print-architecture)
-    if [[ ${BRANCH_NAME} != "main" ]] && [[ ! ${BRANCH_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]]; then package_name="${pkg_name}_${version}-${commit_count}_${arch}"; version=${git_tag_info:1}; else package_name="${pkg_name}-${version}-${arch}"; fi
+    if [[ ${BRANCH_NAME} != "main" ]] && [[ ! ${BRANCH_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]]; then package_name="${pkg_name}_${version}-${commit_count}_${arch}"; version=${git_tag_info:1}; else package_name="${pkg_name}_${version}_${arch}"; fi
 
     # Print the summary of findings
     echo "The package root directory is                         : ${GIT_ROOT}"

--- a/service/make_deb
+++ b/service/make_deb
@@ -127,7 +127,7 @@ do
     git_tag_info=$(git describe --tags) && commit_count=$(echo ${git_tag_info} | cut -d- -f2) || { commit_count=$(git rev-list --count HEAD); git_tag_info="v$version-$commit_count-g$(git rev-parse --short HEAD)"; }
     # Final package name
     archname=$(dpkg --print-architecture)
-    if [[ ${BRANCH_NAME} != "main" ]] && [[ ! ${BRANCH_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]]; then package_name="${pkg_name}_${version}-${commit_count}_${architecture}"; version=${git_tag_info:1}; else package_name="${pkg_name}-${version}-${architecture}"; fi
+    if [[ ${BRANCH_NAME} != "main" ]] && [[ ! ${BRANCH_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+RC ]]; then package_name="${pkg_name}_${version}-${commit_count}_${architecture}"; version=${git_tag_info:1}; else package_name="${pkg_name}_${version}_${architecture}"; fi
 
     # Print the summary of findings
     echo "The package root directory is                           : ${GIT_ROOT}"


### PR DESCRIPTION
Signed-off-by: YashTatkondawar <yashtatkondawar@gmail.com>

Test packages from 1.9.2RC available at: http://archives.fledge-iot.org/fixes/FOGL-5932-1.9.2/ubuntu1804/x86_64/
Please ignore fledge-gui, fledge-mqtt, and fledge-gcp packages as they are not made from the 1.9.2RC branch.