### PR TITLE
FOGL-6130 - make_rpm fixes for any service to build with

### DIFF
--- a/service/make_rpm
+++ b/service/make_rpm
@@ -72,14 +72,14 @@ fi
 # Check if the default directory exists
 echo FLEDGE_ROOT = ${FLEDGE_ROOT}
 if [ "${FLEDGE_ROOT}" = "" ]; then
-echo "Notification server cannot be compiled: FLEDGE_ROOT environment variable is not set."
+echo "${REPO_NAME} service cannot be compiled: FLEDGE_ROOT environment variable is not set."
 echo "Specify the base directory for Fledge and set the variable with:"
 echo "export FLEDGE_ROOT=<basedir>"
 exit 1
 fi
 
 if [ ! -d "${FLEDGE_ROOT}" ]; then
-echo "Notification server cannot be compiled: ${FLEDGE_ROOT} is not a valid directory."
+echo "${REPO_NAME} service cannot be compiled: ${FLEDGE_ROOT} is not a valid directory."
 echo "Specify the base directory for Fledge and set the variable with:"
 echo "export FLEDGE_ROOT=<basedir>"
 exit 1
@@ -137,7 +137,7 @@ do
     pkg_name="${REPO_NAME}"
 
     if [ -f "${GIT_ROOT}/VERSION" ]; then
-        version=`cat "${GIT_ROOT}/VERSION" | tr -d ' ' | grep "notification_version" | head -1 | sed -e 's/\(.*\)version\([>=|>|<|<=|=]*\)\(.*\)/\3/g'`
+        version=`cat "${GIT_ROOT}/VERSION" | tr -d ' ' | grep "${service_name}_version" | head -1 | sed -e 's/\(.*\)version\([>=|>|<|<=|=]*\)\(.*\)/\3/g'`
         fledge_version=`cat ${GIT_ROOT}/VERSION| tr -d ' ' | grep 'fledge_version' | head -1 | sed -e 's/\(.*\)version\([>=|>|<|<=|=]*\)\(.*\)/\2 \3/g'`
     else
         echo Unable to determine version of package to create
@@ -207,6 +207,7 @@ do
     sed -i "s/fledge,/fledge ${fledge_version},/" SPECS/service.spec
     sed -i "s/fledge$/fledge ${fledge_version}/" SPECS/service.spec
     sed -i "s/__VCS__/${git_tag_info:1}/g" SPECS/service.spec
+    sed -i "s/__SERVICE_NAME__/${service_name}/g" SPECS/service.spec
 
     cat > /tmp/sed.script.$$ << EOF
         /__DESCRIPTION__/ {
@@ -232,7 +233,7 @@ EOF
         mkdir -p python/fledge/plugins/notificationRule
     fi
     mkdir -p ${install_dir}
-    cp -R --preserve=links ${GIT_ROOT}/build/C/${install_dir}/notification/fledge* "${install_dir}/"
+    cp -R --preserve=links ${GIT_ROOT}/build/C/${install_dir}/${service_name}/fledge* "${install_dir}/"
     echo "Done."
     cd ..
     find -L . -type f -exec echo '%{install_path}/'{} \; >> ../../../../SPECS/service.spec
@@ -243,8 +244,9 @@ EOF
     # Full Package name
     fullname="${package_name}.${arch}.rpm"
     # Move final package and its spec file to archive/arch directory
-    cp ${BUILD_ROOT}/${package_name}/RPMS/${arch}/${fullname} ${archive}/${arch}/${fullname}
-    cp ${BUILD_ROOT}/${package_name}/SPECS/service.spec ${archive}/${arch}
+    mkdir -p "${archive}/$arch/${service_name}"
+    cp ${BUILD_ROOT}/${package_name}/RPMS/${arch}/${fullname} ${archive}/${arch}/${service_name}/${fullname}
+    cp ${BUILD_ROOT}/${package_name}/SPECS/service.spec ${archive}/${arch}/${service_name}
     # Remove /tmp cloned directory
     rm -rf /tmp/${REPO_NAME}
     exit 0

--- a/service/packages/RPM/SPECS/service.spec
+++ b/service/packages/RPM/SPECS/service.spec
@@ -12,6 +12,7 @@ URL:           http://www.dianomic.com
 VCS:           __VCS__
 
 %define install_path    /usr/local
+%define service_name    __SERVICE_NAME__
 
 Prefix:        /usr/local
 Requires:      __REQUIRES__
@@ -26,7 +27,6 @@ __DESCRIPTION__
 %preun
 PKG_NAME="__PACKAGE_NAME__"
 
-
 %post
 set -e
 set_files_ownership () {
@@ -37,9 +37,10 @@ set_files_ownership () {
 echo "Setting ownership of Fledge files"
 set_files_ownership
 
-
 %files
+%if "%{service_name}" == "notification"
 %{install_path}/fledge/plugins/notificationDelivery
 %{install_path}/fledge/plugins/notificationRule
 %{install_path}/fledge/python/fledge/plugins/notificationDelivery
 %{install_path}/fledge/python/fledge/plugins/notificationRule
+%endif


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

**Make Package**
```
 $ ./make_rpm -b develop fledge-service-dispatcher
FLEDGE_ROOT = /home/aj/Development/fledge
Cloning into 'fledge-service-dispatcher'...
remote: Enumerating objects: 76, done.
remote: Counting objects: 100% (76/76), done.
remote: Compressing objects: 100% (46/46), done.
remote: Total 76 (delta 25), reused 62 (delta 17), pack-reused 0
Unpacking objects: 100% (76/76), done.
fatal: No names found, cannot describe anything.
The package root directory is                           : /tmp/fledge-service-dispatcher
The package build directory is                          : /tmp/fledge-service-dispatcher/build
The Fledge required version                             : >= 1.9
The Fledge service dispatcher version is              : 1.9.2
The architecture is set as                              : x86_64
The package will be built in                            : /home/aj/Development/fledge-pkg/service/archive/Rpm/
The package name is                                     : fledge-service-dispatcher-1.9.2-12

-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Boost version: 1.65.1
-- Found the following Boost libraries:
--   system
--   thread
--   chrono
--   date_time
--   atomic
-- No options set.
   +Using found FLEDGE_ROOT /home/aj/Development/fledge
-- Using FLEDGE_ROOT for includes
   +/home/aj/Development/fledge/C/common/include
   +/home/aj/Development/fledge/C/services/common/include
   +/home/aj/Development/fledge/C/plugins/filter/common/include
   +/home/aj/Development/fledge/C/thirdparty/rapidjson/include
-- Using FLEDGE_ROOT for libs 
   +/home/aj/Development/fledge/cmake_build/C/lib
-- Using third-party includes /home/aj/Development/fledge/C/thirdparty/Simple-Web-Server
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/fledge-service-dispatcher/build
Scanning dependencies of target fledge.services.dispatcher
[ 16%] Building CXX object C/services/dispatcher/CMakeFiles/fledge.services.dispatcher.dir/controlrequest.cpp.o
[ 33%] Building CXX object C/services/dispatcher/CMakeFiles/fledge.services.dispatcher.dir/dispatcher.cpp.o
/tmp/fledge-service-dispatcher/C/services/dispatcher/dispatcher.cpp: In function ‘int makeDaemon()’:
/tmp/fledge-service-dispatcher/C/services/dispatcher/dispatcher.cpp:161:2: warning: ignoring return value of ‘int dup(int)’, declared with attribute warn_unused_result [-Wunused-result]
  (void)dup(0);         // stdout GCC bug 66425 produces warning
  ^~~~~~~~~~~~
/tmp/fledge-service-dispatcher/C/services/dispatcher/dispatcher.cpp:162:2: warning: ignoring return value of ‘int dup(int)’, declared with attribute warn_unused_result [-Wunused-result]
  (void)dup(0);         // stderr GCC bug 66425 produces warning
  ^~~~~~~~~~~~
[ 50%] Building CXX object C/services/dispatcher/CMakeFiles/fledge.services.dispatcher.dir/dispatcher_api.cpp.o
[ 66%] Building CXX object C/services/dispatcher/CMakeFiles/fledge.services.dispatcher.dir/dispatcher_service.cpp.o
[ 83%] Building CXX object C/services/dispatcher/CMakeFiles/fledge.services.dispatcher.dir/kvlist.cpp.o
[100%] Linking CXX executable fledge.services.dispatcher
[100%] Built target fledge.services.dispatcher
Populating the package and updating version file...Copying artifacts...
Done.
Building the RPM package...
Processing files: fledge-service-dispatcher-1.9.2-12.x86_64
Provides: fledge-service-dispatcher = 1.9.2-12 fledge-service-dispatcher(x86-64) = 1.9.2-12
Requires(interp): /bin/sh /bin/sh /bin/sh
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires(pre): /bin/sh
Requires(post): /bin/sh
Requires(preun): /bin/sh
Checking for unpackaged file(s): /usr/lib/rpm/check-files /tmp/fledge-service-dispatcher/build/fledge-service-dispatcher-1.9.2-12/BUILDROOT/fledge-service-dispatcher-1.9.2-12.x86_64
Wrote: /tmp/fledge-service-dispatcher/build/fledge-service-dispatcher-1.9.2-12/RPMS/x86_64/fledge-service-dispatcher-1.9.2-12.x86_64.rpm
Building Complete.

```

**Content of Package**
```
$ rpm -qlp fledge-service-dispatcher-1.9.2-12.x86_64.rpm 
/usr/local/fledge/services/fledge.services.dispatcher

**Content of Package with script**
[centos@ip-10-0-0-125 ~]$ rpm -qlp --scripts fledge-service-dispatcher-1.9.2-12.x86_64.rpm 
preinstall program: /bin/sh
postinstall scriptlet (using /bin/sh):
set -e
set_files_ownership () {
    chown -R root:root /usr/local/fledge/services
}

# main
echo "Setting ownership of Fledge files"
set_files_ownership
preuninstall scriptlet (using /bin/sh):
PKG_NAME="fledge-service-dispatcher-1.9.2-12"
/usr/local/fledge/services/fledge.services.dispatcher
```

**Package installation**
```
$ sudo yum install -y ./fledge-service-dispatcher-1.9.2-12.x86_64.rpm 
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror
Examining ./fledge-service-dispatcher-1.9.2-12.x86_64.rpm: fledge-service-dispatcher-1.9.2-12.x86_64
Marking ./fledge-service-dispatcher-1.9.2-12.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package fledge-service-dispatcher.x86_64 0:1.9.2-12 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

=====================================================================================================================================================================================
 Package                                         Arch                         Version                         Repository                                                        Size
=====================================================================================================================================================================================
Installing:
 fledge-service-dispatcher                       x86_64                       1.9.2-12                        /fledge-service-dispatcher-1.9.2-12.x86_64                       863 k

Transaction Summary
=====================================================================================================================================================================================
Install  1 Package

Total size: 863 k
Installed size: 863 k
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : fledge-service-dispatcher-1.9.2-12.x86_64                                                                                                                         1/1 
Setting ownership of Fledge files
  Verifying  : fledge-service-dispatcher-1.9.2-12.x86_64                                                                                                                         1/1 

Installed:
  fledge-service-dispatcher.x86_64 0:1.9.2-12                                                                                                                                        

Complete!
```

**Installation info**
```
[centos@ip-10-0-0-125 ~]$ sudo yum list installed | grep fledge
Failed to set locale, defaulting to C
fledge.x86_64                         1.9.2-218                 @fledge         
fledge-gui.x86_64                     1.9.2next-65              @fledge         
fledge-service-dispatcher.x86_64      1.9.2-12                  @/fledge-service-dispatcher-1.9.2-12.x86_64
fledge-service-notification.x86_64    1.9.2-8                   @fledge  
```

**Verify service is installed via Curl**
```
$ curl -sX GET localhost:8081/fledge/service/installed
{"services": ["north", "south", "storage", "notification", "dispatcher"]}
```