### PR TITLE
FOGL-5798 s2opcua common additional package files support added for Debian Platform only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ others/paho.mqtt.c/
 others/jansson
 others/lib60870
 others/libiec61850
+others/S2OPC
+others/check-0.15.2.tar.gz
+others/check-0.15.2
+others/libexpat
 
 # Archived packages
 plugins/archive

--- a/others/make_deb
+++ b/others/make_deb
@@ -142,6 +142,13 @@ if [ "${ADDITIONAL_LIB_NAME}" == "iec" ];  then
     fi
     cp -R --preserve=links /usr/local/lib/liblib60870* usr/local/lib
 fi
+if [ "${ADDITIONAL_LIB_NAME}" == "s2opcua" ];  then
+    cp -R --preserve=links /usr/local/lib/libs2opc_common.so usr/local/lib
+    cp -R --preserve=links /usr/local/lib/libs2opc_clientserver.so usr/local/lib
+    cp -R --preserve=links /usr/local/lib/libs2opc_clientwrapper.so usr/local/lib
+    cp -R --preserve=links /usr/local/lib/libs2opc_commonwrapper.so usr/local/lib
+    cp -R --preserve=links /usr/local/lib/libexpat.so.1 usr/local/lib
+fi
 echo "Done."
 
 # Build the package

--- a/others/scripts/s2opcua/Description
+++ b/others/scripts/s2opcua/Description
@@ -1,0 +1,1 @@
+This Package contains an Expat, a C library for parsing XML and OPC UA Toolkit additional libraries.

--- a/others/scripts/s2opcua/S2OPC.patch
+++ b/others/scripts/s2opcua/S2OPC.patch
@@ -1,0 +1,114 @@
+diff --git a/CommonDefs.cmake b/CommonDefs.cmake
+index 7cca75030..b22079425 100644
+--- a/CommonDefs.cmake
++++ b/CommonDefs.cmake
+@@ -29,8 +29,8 @@ endforeach(OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES)
+ ## Manage static/shared property of external libraries
+ 
+ # Make CMake use static version of all dependencies by default
+-option(USE_STATIC_EXT_LIBS "S2OPC libraries and binaries depend on static version of external libraries" ON)
+-option(BUILD_SHARED_LIBS "Build dynamic libraries for S2OPC instead of static libraries" OFF)
++option(USE_STATIC_EXT_LIBS "S2OPC libraries and binaries depend on static version of external libraries" OFF)
++option(BUILD_SHARED_LIBS "Build dynamic libraries for S2OPC instead of static libraries" ON)
+ if(USE_STATIC_EXT_LIBS)
+   set(USE_STATIC_MBEDTLS_LIB ${USE_STATIC_EXT_LIBS})
+   set(USE_STATIC_EXPAT_LIB ${USE_STATIC_EXT_LIBS})
+diff --git a/src/ClientServer/frontend/client_wrapper/libs2opc_client.h b/src/ClientServer/frontend/client_wrapper/libs2opc_client.h
+index 693c63ab0..24c67dac2 100644
+--- a/src/ClientServer/frontend/client_wrapper/libs2opc_client.h
++++ b/src/ClientServer/frontend/client_wrapper/libs2opc_client.h
+@@ -129,7 +129,9 @@ typedef enum
+     SOPC_LibSub_DataType_integer = 2,
+     SOPC_LibSub_DataType_string = 3,
+     SOPC_LibSub_DataType_bytestring = 4,
+-    SOPC_LibSub_DataType_other = 5
++    SOPC_LibSub_DataType_float = 5,
++	SOPC_LibSub_DataType_double = 6,
++    SOPC_LibSub_DataType_other = 7
+ } SOPC_LibSub_DataType;
+ 
+ /**
+diff --git a/src/ClientServer/frontend/client_wrapper/state_machine.c b/src/ClientServer/frontend/client_wrapper/state_machine.c
+index 1ab4df97d..b2eef008a 100644
+--- a/src/ClientServer/frontend/client_wrapper/state_machine.c
++++ b/src/ClientServer/frontend/client_wrapper/state_machine.c
+@@ -1298,10 +1298,12 @@ static void StaMac_ProcessMsg_PublishResponse(SOPC_StaMac_Machine* pSM, uint32_t
+         assert(SOPC_ExtObjBodyEncoding_Object == pNotifMsg->NotificationData[0].Encoding);
+         assert(&OpcUa_DataChangeNotification_EncodeableType == pNotifMsg->NotificationData[0].Body.Object.ObjType);
+         pDataNotif = (OpcUa_DataChangeNotification*) pNotifMsg->NotificationData[0].Body.Object.Value;
++		Helpers_Log(SOPC_LOG_LEVEL_INFO, "%s:%d: pDataNotif->NoOfMonitoredItems=%d", "StaMac_ProcessMsg_PublishResponse", __LINE__, pDataNotif->NoOfMonitoredItems);
+         for (i = 0; i < pDataNotif->NoOfMonitoredItems; ++i)
+         {
+             pMonItNotif = &pDataNotif->MonitoredItems[i];
+             status = Helpers_NewValueFromDataValue(&pMonItNotif->Value, &plsVal);
++			Helpers_Log(SOPC_LOG_LEVEL_INFO, "%s:%d: i=%d, plsVal->type=%d", "StaMac_ProcessMsg_PublishResponse", __LINE__, i, plsVal->type);
+             if (SOPC_STATUS_OK == status)
+             {
+                 if (NULL != pSM->cbkLibSubDataChanged)
+diff --git a/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c b/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c
+index e2fa388ff..b4babe046 100644
+--- a/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c
++++ b/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c
+@@ -111,8 +111,8 @@ SOPC_ReturnStatus Helpers_NewSCConfigFromLibSubCfg(const char* szServerUrl,
+             status = SOPC_PKIProviderStack_CreateFromPaths(lPathsTrustedRoots, lPathsTrustedLinks, lPathsUntrustedRoots,
+                                                            lPathsUntrustedLinks, lPathsIssuedCerts, lPathsCRL, &pPki);
+             if (SOPC_STATUS_OK != status)
+-            {
+-                Helpers_Log(SOPC_LOG_LEVEL_ERROR, "Failed to create PKI.");
++            {
++                Helpers_Log(SOPC_LOG_LEVEL_ERROR, "Failed to create PKI, status=%d", status);
+             }
+         }
+         else
+@@ -536,9 +536,36 @@ SOPC_ReturnStatus Helpers_NewValueFromDataValue(SOPC_DataValue* pVal, SOPC_LibSu
+             }
+             /* else we leave value NULL and length = 0 */
+             break;
++
++		case SOPC_Float_Id:
++            plsVal->type = SOPC_LibSub_DataType_float;
++            plsVal->value = SOPC_Malloc(sizeof(float));
++            if (NULL == plsVal->value)
++            {
++                status = SOPC_STATUS_OUT_OF_MEMORY;
++            }
++            else
++            {
++                *(float*) plsVal->value = (float) pVal->Value.Value.Floatv;
++            }
++            break;
++
++		case SOPC_Double_Id:
++            plsVal->type = SOPC_LibSub_DataType_double;
++            plsVal->value = SOPC_Malloc(sizeof(double));
++            if (NULL == plsVal->value)
++            {
++                status = SOPC_STATUS_OUT_OF_MEMORY;
++            }
++            else
++            {
++                *(double*) plsVal->value = (double) pVal->Value.Value.Doublev;
++            }
++            break;
++
+         case SOPC_Null_Id:
+-        case SOPC_Float_Id:
+-        case SOPC_Double_Id:
++        // case SOPC_Float_Id:
++        // case SOPC_Double_Id:
+         case SOPC_DateTime_Id:
+         case SOPC_Guid_Id:
+         case SOPC_XmlElement_Id:
+diff --git a/src/Common/configuration/sopc_common_constants.h b/src/Common/configuration/sopc_common_constants.h
+index 874129c1e..9e24ed808 100644
+--- a/src/Common/configuration/sopc_common_constants.h
++++ b/src/Common/configuration/sopc_common_constants.h
+@@ -77,7 +77,7 @@ bool SOPC_Common_SetEncodingConstants(SOPC_Common_EncodingConstants config);
+  *  Note: if 0 is chosen SOPC_RECEIVE_MAX_MESSAGE_LENGTH definition shall be changed not to use it and shall not be 0.
+  */
+ #ifndef SOPC_DEFAULT_RECEIVE_MAX_NB_CHUNKS
+-#define SOPC_DEFAULT_RECEIVE_MAX_NB_CHUNKS 5
++#define SOPC_DEFAULT_RECEIVE_MAX_NB_CHUNKS 10
+ #endif /* SOPC_DEFAULT_RECEIVE_MAX_NB_CHUNKS */
+ 
+ /** @brief Maximum message length accepted in reception (must be >= SOPC_TCP_UA_MAX_BUFFER_SIZE), 0 means no limit.

--- a/others/scripts/s2opcua/VERSION
+++ b/others/scripts/s2opcua/VERSION
@@ -1,0 +1,2 @@
+fledge_s2opcua_version=1.9.2
+fledge_version>=1.9

--- a/others/scripts/s2opcua/check-0.15.2_CMakeLists.txt.patch
+++ b/others/scripts/s2opcua/check-0.15.2_CMakeLists.txt.patch
@@ -1,0 +1,12 @@
+--- CMakeLists.txt	2021-04-27 14:35:52.359863999 +0530
++++ CMakeLists.txt.updated	2021-04-27 14:26:16.551912000 +0530
+@@ -248,7 +248,9 @@
+   check_c_compiler_flag("-pthread" HAVE_PTHREADS_FLAG)
+   if (HAVE_PTHREADS_FLAG)
+     add_definitions("-pthread")
+-    add_link_options("-pthread")
++    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pthread")
++    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
++    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+   endif()
+ endif()

--- a/others/scripts/s2opcua/include/sopc_encodeabletype.h
+++ b/others/scripts/s2opcua/include/sopc_encodeabletype.h
@@ -1,0 +1,184 @@
+/*
+ * Licensed to Systerel under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Systerel licenses this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ *  \file sopc_encodeabletype.h
+ *
+ *  \brief Encodeable type and services
+ */
+
+#ifndef SOPC_ENCODEABLETYPE_H_
+#define SOPC_ENCODEABLETYPE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sopc_buffer.h"
+#include "sopc_enums.h"
+
+/**
+ *  \brief Initialization function generic signature for an encodeable object
+ */
+typedef void(SOPC_EncodeableObject_PfnInitialize)(void* value);
+
+/**
+ *  \brief Clear function generic signature for an encodeable object
+ */
+typedef void(SOPC_EncodeableObject_PfnClear)(void* value);
+
+/**
+ *  \brief Get size function generic signature for an encodeable object
+ *  Note: Unused in S2OPC, NULL pointer may be provided instead of function pointer
+ */
+typedef void(SOPC_EncodeableObject_PfnGetSize)(void);
+
+/**
+ *  \brief Encoding function generic signature for an encodeable object
+ */
+typedef SOPC_ReturnStatus(SOPC_EncodeableObject_PfnEncode)(const void* value,
+                                                           SOPC_Buffer* msgBuffer,
+                                                           uint32_t nestedStructLevel);
+
+/**
+ *  \brief Decoding function generic signature for an encodeable object
+ */
+typedef SOPC_ReturnStatus(SOPC_EncodeableObject_PfnDecode)(void* value,
+                                                           SOPC_Buffer* msgBuffer,
+                                                           uint32_t nestedStructLevel);
+
+/*
+ * \brief Description of an encodeable type field.
+ *
+ * This structure has been designed to be very compact and fit into 8 bytes.
+ * The \c isBuiltIn field indicates whether the field type is built-in or
+ * defined in the address space.  In the first case, the type index is a member
+ * of the \c SOPC_BuiltinId enumeration.  In the second case, it is a member of
+ * the \c SOPC_TypeInternalIndex enumeration.
+ *
+ * The \c isArrayLength field indicates whether this field contains the length
+ * of an array.  When true, the field must be of built-in type \c Int32, and the
+ * array is described by the next field.
+ *
+ * The \c isToEncode field indicates whether this field shall be encoded and
+ * decoded.  When false, the field is only initialized and cleared.
+ *
+ * Finally, the \c offset field gives the offset in bytes of the field in the
+ * object structure.
+ */
+typedef struct SOPC_EncodeableType_FieldDescriptor
+{
+    bool isBuiltIn : 1;
+    bool isArrayLength : 1;
+    bool isToEncode : 1;
+    uint32_t typeIndex : 29;
+    uint32_t offset;
+} SOPC_EncodeableType_FieldDescriptor;
+
+/**
+ *  \brief Encodeable object type structure definition. It provides all the services
+ *  functions associated with the encodeable object for encoding needs.
+ */
+typedef struct SOPC_EncodeableType
+{
+    char* TypeName;
+    uint32_t TypeId;
+    uint32_t BinaryEncodingTypeId;
+    uint32_t XmlEncodingTypeId;
+    char* NamespaceUri;
+    size_t AllocationSize;
+    SOPC_EncodeableObject_PfnInitialize* Initialize;
+    SOPC_EncodeableObject_PfnClear* Clear;
+    SOPC_EncodeableObject_PfnGetSize* GetSize;
+    SOPC_EncodeableObject_PfnEncode* Encode;
+    SOPC_EncodeableObject_PfnDecode* Decode;
+    int32_t NoOfFields;
+    const SOPC_EncodeableType_FieldDescriptor* Fields;
+} SOPC_EncodeableType;
+
+/**
+ * \brief       Registers a user-defined encodeable type.
+ *              further calls to SOPC_EncodeableType_GetEncodeableType
+ *              will successfully identify the registered encodeable type
+ *
+ * \note        All registered encoders must be freed by
+ *              SOPC_EncodeableType_RemoveUserType
+ *
+ *  \param encoder        The encoder definition to register
+ *  \return               A status code indicating the result of operation
+ */
+SOPC_ReturnStatus SOPC_EncodeableType_AddUserType(SOPC_EncodeableType* encoder);
+
+/**
+ * \brief       Removes a user-defined encodeable type previously created by
+ *                      SOPC_EncodeableType_AddUserType
+ *
+ *  \param encoder        The encoder definition to register
+ *  \return               A status code indicating the result of operation
+ */
+SOPC_ReturnStatus SOPC_EncodeableType_RemoveUserType(SOPC_EncodeableType* encoder);
+
+/**
+ *  \brief          Retrieve a defined encodeable object type with the given type Id.
+ *
+ *  \param typeId         Type identifier for which corresponding encodeable object type must be returned
+ *  \return               The searched encodeable type or NULL if parameters are incorrect or type is not found
+ */
+SOPC_EncodeableType* SOPC_EncodeableType_GetEncodeableType(uint32_t typeId);
+
+const char* SOPC_EncodeableType_GetName(SOPC_EncodeableType* encType);
+
+/**
+ * \brief Initialize an encodeable object.
+ *
+ * The \c pValue parameter shall correspond to an object of the appropriate
+ * type.
+ */
+void SOPC_EncodeableObject_Initialize(SOPC_EncodeableType* type, void* pValue);
+
+/**
+ * \brief Clear an encodeable object.
+ *
+ * The \c pValue parameter shall correspond to an object of the appropriate
+ * type.
+ */
+void SOPC_EncodeableObject_Clear(SOPC_EncodeableType* type, void* pValue);
+
+/**
+ * \brief Encode an encodeable object.
+ *
+ * The \c pValue parameter shall correspond to an object of the appropriate
+ * type.
+ */
+SOPC_ReturnStatus SOPC_EncodeableObject_Encode(SOPC_EncodeableType* type,
+                                               const void* pValue,
+                                               SOPC_Buffer* buf,
+                                               uint32_t nestedStructLevel);
+
+/**
+ * \brief Decode an encodeable object.
+ *
+ * The \c pValue parameter shall correspond to an object of the appropriate
+ * type.
+ */
+SOPC_ReturnStatus SOPC_EncodeableObject_Decode(SOPC_EncodeableType* type,
+                                               void* pValue,
+                                               SOPC_Buffer* buf,
+                                               uint32_t nestedStructLevel);
+
+#endif /* SOPC_ENCODEABLETYPE_H_ */

--- a/others/scripts/s2opcua/requirements.sh
+++ b/others/scripts/s2opcua/requirements.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+##---------------------------------------------------------------------------
+## Copyright (c) 2022 Dianomic Systems Inc.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##---------------------------------------------------------------------------
+
+##
+## Author: Ashish Jabble
+##
+
+set -e
+
+os_name=`(grep -o '^NAME=.*' /etc/os-release | cut -f2 -d\" | sed 's/"//g')`
+os_version=`(grep -o '^VERSION_ID=.*' /etc/os-release | cut -f2 -d\" | sed 's/"//g')`
+echo "Platform is ${os_name}, Version: ${os_version}"
+
+# mbedtls-dev:
+if [[  $os_name == *"Red Hat"* || $os_name == *"CentOS"* ]]; then
+    echo "RHEL/CentOS platform is not currently supported by this plugin."
+    exit 1
+else
+    sudo apt-get install -y libmbedtls-dev
+fi
+
+# libexpat:
+rm -rf libexpat
+echo "Fetching an Expat, a C library for parsing XML..."
+git clone https://github.com/libexpat/libexpat.git
+(
+	cd libexpat/expat
+	./buildconf.sh && \
+	./configure && \
+	make && \
+	sudo make install
+)
+
+# libcheck:
+rm -rf check-0.15.2 check-0.15.2.tar.gz*
+wget https://github.com/libcheck/check/releases/download/0.15.2/check-0.15.2.tar.gz
+tar xf check-0.15.2.tar.gz
+(
+	cd check-0.15.2
+	cp ../scripts/s2opcua/check-0.15.2_CMakeLists.txt.patch .
+	patch < check-0.15.2_CMakeLists.txt.patch  # update the CMakeLists.txt file
+	rm -f CMakeCache.txt
+	mkdir -p build
+	cd build
+	cmake .. && make -j4 && sudo make install
+)
+
+# S2OPC:
+rm -rf S2OPC
+echo "Fetching S2OPC OPC UA Toolkit libraries..."
+git clone https://gitlab.com/systerel/S2OPC.git
+(
+	cd S2OPC
+	cp ../scripts/s2opcua/S2OPC.patch .
+	git apply S2OPC.patch
+	cp ./src/Common/opcua_types/sopc_encodeabletype.h ../scripts/s2opcua/include
+	ed ../scripts/s2opcua/include/sopc_encodeabletype.h << EOED
+,s/typedef const struct SOPC_EncodeableType/typedef struct SOPC_EncodeableType/1
+w
+q
+EOED
+	BUILD_SHARED_LIBS=OFF
+	CMAKE_INSTALL_PREFIX=/usr/local
+	./build.sh
+	echo
+	echo "BUILD done, INSTALLING..."
+	echo
+	cd build
+	sudo make install
+)


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

Custom Packages are available at - http://archives.fledge-iot.org/fixes/FOGL-5798

**Debian contents**
```
$ sudo dpkg -c fledge-s2opcua_1.9.2-46_x86_64.deb 
[sudo] password for aj: 
drwxrwxr-x ubuntu/ubuntu     0 2022-05-26 13:14 ./
drwxrwxr-x ubuntu/ubuntu     0 2022-05-26 13:14 ./usr/
drwxrwxr-x ubuntu/ubuntu     0 2022-05-26 13:14 ./usr/local/
drwxrwxr-x ubuntu/ubuntu     0 2022-05-26 13:14 ./usr/local/lib/
-rw-r--r-- ubuntu/ubuntu 3088328 2022-05-26 13:14 ./usr/local/lib/libs2opc_clientserver.so
-rw-r--r-- ubuntu/ubuntu  318872 2022-05-26 13:14 ./usr/local/lib/libs2opc_clientwrapper.so
-rw-r--r-- ubuntu/ubuntu 1661648 2022-05-26 13:14 ./usr/local/lib/libs2opc_common.so
-rw-r--r-- ubuntu/ubuntu  101784 2022-05-26 13:14 ./usr/local/lib/libs2opc_commonwrapper.so
lrwxrwxrwx ubuntu/ubuntu       0 2022-05-26 13:14 ./usr/local/lib/libexpat.so.1 -> libexpat.so.1.8.8
```

Verified its installation and discovery is fine on ub18, ub20, Rpi + buster platforms