### PR TITLE
FOGL-6525 pip3 upgrade fix for aiohttp package

### DIFF
--- a/packages/Debian/common/DEBIAN/postinst
+++ b/packages/Debian/common/DEBIAN/postinst
@@ -113,6 +113,7 @@ copy_new_data () {
 }
 
 install_pip3_packages () {
+    pip3 install --upgrade pip
     pip3 install -r /usr/local/fledge/python/requirements.txt
 }
 


### PR DESCRIPTION
aarch64/arm64 builds requires pip3 to be upgraded for aiohttp package install; This issue was see on ubuntu18.04 aarch64 though may also appear on Coral Mendel. The fix is good to go with all platforms