### PR TITLE
FOGL-7373 - sqlite yum package dependency added & other pip command fixes for a plugin

### DIFF
--- a/packages/RPM/SPECS/fledge.spec
+++ b/packages/RPM/SPECS/fledge.spec
@@ -18,7 +18,7 @@ Prefix:        /usr/local
 %if 0%{?centos} < 9 || 0%{?rhel} < 9
 Requires:      dbus-devel, glib2-devel, boost, openssl, rh-python36, yum-utils, gcc, autoconf, curl, libtool, rsyslog, wget, zlib, libuuid, avahi, sudo, krb5-workstation, curl-devel
 %else
-Requires:      dbus-devel, glib2-devel, boost, openssl, python3-devel, yum-utils, gcc, autoconf, curl, libtool, rsyslog, wget, zlib, libuuid, avahi, sudo, krb5-workstation, curl-devel, chkconfig
+Requires:      dbus-devel, glib2-devel, boost, openssl, python3-devel, yum-utils, gcc, autoconf, curl, libtool, rsyslog, wget, zlib, libuuid, avahi, sudo, krb5-workstation, curl-devel, chkconfig, sqlite
 %endif
 AutoReqProv:   no
 

--- a/plugins/packages/RPM/SPECS/plugin.spec
+++ b/plugins/packages/RPM/SPECS/plugin.spec
@@ -111,6 +111,7 @@ PKG_NAME="__PACKAGE_NAME__"
 set -e
 
 
+OS_VERSION=$(cat /etc/os-release | grep 'VERSION_ID=' | cut -f2 -d= | sed 's/"//g')
 
 set_files_ownership () {
 	chown -R root:root /usr/local/fledge/__INSTALL_DIR__
@@ -127,10 +128,8 @@ fi
 
 # Install any Python dependencies
 if [ -f /usr/local/fledge/__INSTALL_DIR__/requirements.txt ]; then
-	bash << EOF
-scl enable rh-python36 bash
-pip install -Ir /usr/local/fledge/__INSTALL_DIR__/requirements.txt
-EOF
+    if [[ ${OS_VERSION} == *"7"* ]]; then source scl_source enable rh-python36 bash; fi
+    python3 -m pip install -Ir /usr/local/fledge/__INSTALL_DIR__/requirements.txt
 fi
 
 echo __PLUGIN_NAME__ __PLUGIN_TYPE__ plugin is installed.


### PR DESCRIPTION
Custom Packages are available at - http://archives.fledge-iot.org/fixes/FOGL-7373/centos-stream-9/x86_64/

Plugins to test with on-demand south-coap, south-modbustcp, north-opcuaclient, north-azure - has python requirements.txt.