### PR TITLE
FOGL-7583 .Package file added in RPM plugin packaging

### DIFF
--- a/plugins/make_rpm
+++ b/plugins/make_rpm
@@ -248,6 +248,7 @@ EOF
 	    fi
 	    cp -R ${GIT_ROOT}/python .
 	    cp -R ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} ./python/fledge/plugins/${plugin_type}/${plugin_name}
+	    echo ${pkg_name} > ./python/fledge/plugins/${plugin_type}/${plugin_name}/.Package
 	else
       (cd ${GIT_ROOT};
       if [ -f requirements.sh ]; then
@@ -261,6 +262,7 @@ EOF
           mkdir -p build; cd build; cmake ..; make
       fi)
       mkdir -p "plugins/${plugin_type_install}/${plugin_install_dirname}"
+      echo ${pkg_name} > plugins/${plugin_type_install}/${plugin_install_dirname}/.Package
       cp -R --preserve=links ${GIT_ROOT}/build/lib* "plugins/${plugin_type_install}/${plugin_install_dirname}" 2>/dev/null || \
       cp -R --preserve=links ${GIT_ROOT}/*.json "plugins/${plugin_type_install}/${plugin_install_dirname}" 2>/dev/null || \
       echo "Unable to find libraries in ${GIT_ROOT}/build and json config files in ${GIT_ROOT}, cannot proceed..."


### PR DESCRIPTION
Below are the package contents for different plugins

```
$
./usr/local/fledge/plugins/south/lathesim/.Package
./usr/local/fledge/plugins/south/lathesim/liblathesim.so
./usr/local/fledge/plugins/south/lathesim/liblathesim.so.1
$ cat ./usr/local/fledge/plugins/south/lathesim/.Package
fledge-south-lathe

$
./usr/local/fledge/python/fledge/plugins/south/sinusoid/.Package
./usr/local/fledge/python/fledge/plugins/south/sinusoid/VERSION.south.sinusoid
./usr/local/fledge/python/fledge/plugins/south/sinusoid/__init__.py
./usr/local/fledge/python/fledge/plugins/south/sinusoid/readme.rst
./usr/local/fledge/python/fledge/plugins/south/sinusoid/sinusoid.py
$cat ./usr/local/fledge/python/fledge/plugins/south/sinusoid/.Package 
fledge-south-sinusoid

$
./usr/local/fledge/python/fledge/plugins/north/http_north/.Package
./usr/local/fledge/python/fledge/plugins/north/http_north/VERSION.north.http_north
./usr/local/fledge/python/fledge/plugins/north/http_north/__init__.py
./usr/local/fledge/python/fledge/plugins/north/http_north/http_north.py
$ cat ./usr/local/fledge/python/fledge/plugins/north/http_north/.Package
fledge-north-http-north

$
./usr/local/fledge/plugins/filter/asset/.Package
./usr/local/fledge/plugins/filter/asset/libasset.so
./usr/local/fledge/plugins/filter/asset/libasset.so.1
$ cat ./usr/local/fledge/plugins/filter/asset/.Package
fledge-filter-asset

$
./usr/local/fledge/plugins/notificationDelivery/Telegram/.Package
./usr/local/fledge/plugins/notificationDelivery/Telegram/libTelegram.so
./usr/local/fledge/plugins/notificationDelivery/Telegram/libTelegram.so.1
$ cat ./usr/local/fledge/plugins/notificationDelivery/Telegram/.Package
fledge-notify-telegram

$
./usr/local/fledge/plugins/notificationRule/Average/.Package
./usr/local/fledge/plugins/notificationRule/Average/libAverage.so
./usr/local/fledge/plugins/notificationRule/Average/libAverage.so.1
$ cat ./usr/local/fledge/plugins/notificationRule/Average/.Package
fledge-rule-average
```
Here is the discovery of plugin along with package name which is from .Package file

```
$ curl -sX GET localhost:8081/fledge/plugins/installed | jq
{
 “plugins”: [
  {
   “name”: “http_north”,
   “type”: “north”,
   “description”: “HTTP North Plugin”,
   “version”: “2.1.1”,
   “installedDirectory”: “north/http_north”,
   “packageName”: “fledge-north-http-north”
  },
  {
   “name”: “OMF”,
   “type”: “north”,
   “description”: “PI Server North C Plugin”,
   “version”: “2.1.1”,
   “installedDirectory”: “north/OMF”,
   “packageName”: “”
  },
  {
   “name”: “sinusoid”,
   “type”: “south”,
   “description”: “Sinusoid Poll Plugin which implements sine wave with data points”,
   “version”: “2.1.1”,
   “installedDirectory”: “south/sinusoid”,
   “packageName”: “fledge-south-sinusoid”
  },
  {
   “name”: “lathesim”,
   “type”: “south”,
   “description”: “A simulation of a lathe”,
   “version”: “2.1.1”,
   “installedDirectory”: “south/lathesim”,
   “packageName”: “fledge-south-lathesim”
  },
  {
   “name”: “asset”,
   “type”: “filter”,
   “description”: “Asset filter plugin”,
   “version”: “2.1.1”,
   “installedDirectory”: “filter/asset”,
   “packageName”: “fledge-filter-asset”
  },
  {
   “name”: “Telegram”,
   “type”: “notify”,
   “description”: “Telegram notification delivery C plugin”,
   “version”: “2.1.1”,
   “installedDirectory”: “notificationDelivery/Telegram”,
   “packageName”: “fledge-notify-telegram”
  },
  {
   “name”: “Average”,
   “type”: “rule”,
   “description”: “Trigger if the current value deviates from the moving average by more than a defined percentage”,
   “version”: “2.1.1”,
   “installedDirectory”: “notificationRule/Average”,
   “packageName”: “fledge-rule-average”
  }
 ]
}
```