### PR TITLE
FOGL-8313 paho mqtt library checkout with specific tag and also fixes cmake syn…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ others/S2OPC
 others/check-0.15.2.tar.gz
 others/check-0.15.2
 others/libexpat
+others/scripts/mqtt/paho.mqtt.c*
 
 # Archived packages
 plugins/archive

--- a/others/scripts/mqtt/paho-mqtt-cpp.patch
+++ b/others/scripts/mqtt/paho-mqtt-cpp.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e2b934a..9d5e9a0 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -94,7 +94,7 @@ target_compile_definitions(paho-cpp-objs PRIVATE PAHO_MQTTPP_EXPORTS)
+ target_compile_options(paho-cpp-objs PRIVATE
+   $<$<CXX_COMPILER_ID:MSVC>:/W3>
+   $<$<CXX_COMPILER_ID:Clang>:-Wall -Wextra -Wdocumentation>
+-  $<$<NOT:$<CXX_COMPILER_ID:MSVC,Clang>>:-Wall -Wextra>
++  $<$<NOT:$<OR:$<CXX_COMPILER_ID:MSVC>,$<CXX_COMPILER_ID:Clang>>>:-Wall -Wextra>
+ )
+ 
+ ## --- Build the shared library, if requested ---

--- a/others/scripts/mqtt/requirements.sh
+++ b/others/scripts/mqtt/requirements.sh
@@ -65,7 +65,7 @@ git clone --depth 1 --branch v1.3.1 https://github.com/eclipse/paho.mqtt.cpp
 cd paho.mqtt.cpp
 cp ../scripts/mqtt/paho-mqtt-cpp.patch .
 git apply paho-mqtt-cpp.patch
-cmake -Bbuild -H. -DPAHO_BUILD_STATIC=ON -DPAHO_WITH_SSL=ON -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=FALSE
+cmake -Bbuild -H. -DPAHO_WITH_SSL=ON -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=FALSE
 sudo cmake --build build/ --target install
 sudo ldconfig
 cd ..

--- a/others/scripts/mqtt/requirements.sh
+++ b/others/scripts/mqtt/requirements.sh
@@ -49,7 +49,7 @@ else
 	  echo "Requirements are not supported for platform: ${os_name} and having version: ${os_version}"
 fi
 rm -rf paho.mqtt.c
-git clone https://github.com/eclipse/paho.mqtt.c.git
+git clone --depth 1 --branch v1.3.13 https://github.com/eclipse/paho.mqtt.c.git
 cd paho.mqtt.c
 mkdir build
 cd build
@@ -61,8 +61,10 @@ cd ..
 cd ..
 
 rm -rf paho.mqtt.cpp
-git clone https://github.com/eclipse/paho.mqtt.cpp
+git clone --depth 1 --branch v1.3.1 https://github.com/eclipse/paho.mqtt.cpp
 cd paho.mqtt.cpp
+cp ../scripts/mqtt/paho-mqtt-cpp.patch .
+git apply paho-mqtt-cpp.patch
 cmake -Bbuild -H. -DPAHO_BUILD_STATIC=ON -DPAHO_WITH_SSL=ON -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=FALSE
 sudo cmake --build build/ --target install
 sudo ldconfig


### PR DESCRIPTION
…tax versions with own patch


Custom build passes with the change. Here are the custom packages http://archives.fledge-iot.org/fixes/FOGL-8313/

Note: mqtt sparkplug is already merged and available in nightly though its installation will work when this PR got merged